### PR TITLE
Revert "[INF-1432] adding caches capabilities"

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -130,14 +130,9 @@ class nginx (
   validate_string($proxy_http_version)
   validate_bool($confd_purge)
   validate_bool($vhost_purge)
-
-  if ( $proxy_cache_path != false) {
-    if ( is_string($proxy_cache_path) or is_hash($proxy_cache_path)) {}
-    else {
-      fail('proxy_cache_path must be a string or a hash')
-    }
+  if ($proxy_cache_path != false) {
+    validate_string($proxy_cache_path)
   }
-
   if (!is_integer($proxy_cache_levels)) {
     fail('$proxy_cache_levels must be an integer.')
   }

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -62,12 +62,8 @@ http {
   gzip_disable "MSIE [1-6]\.(?!.*SV1)";
 <% end -%>
 
-<% if @proxy_cache_path.is_a?(Hash) -%>
-<% @proxy_cache_path.sort_by{|k,v| k}.each do |key,value| -%>
-  proxy_cache_path        <%= key %> keys_zone=<%= value %> levels=<%= @proxy_cache_levels %> max_size=<%= @proxy_cache_max_size %> inactive=<%= @proxy_cache_inactive -%>;
-<% end -%>
-<% elsif @proxy_cache_path -%>
-  proxy_cache_path        <%= @proxy_cache_path %> levels=<%= @proxy_cache_levels %> keys_zone=<%= @proxy_cache_keys_zone %> max_size=<%= @proxy_cache_max_size %> inactive=<%= @proxy_cache_inactive -%>;
+<% if @proxy_cache_path -%>
+  proxy_cache_path    <%= @proxy_cache_path %> levels=<%= @proxy_cache_levels %> keys_zone=<%= @proxy_cache_keys_zone %> max_size=<%= @proxy_cache_max_size %> inactive=<%= @proxy_cache_inactive %>;
 <% end -%>
 
 <% if @fastcgi_cache_path -%>


### PR DESCRIPTION
Reverts BedeGaming/puppet-nginx#1

The /var/cache/nginx path doesnt exist and isnt managed anywhere, so this breaks new system builds.

Reverting.  Please test on new builds before tying again.